### PR TITLE
Add image thumbnails, plant history export, and room reordering

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,8 @@ datasource db {
 model Room {
   id        String   @id @default(cuid())
   name      String
+  // custom ordering for drag-and-drop UI
+  sortOrder Int      @default(0)
   createdAt DateTime @default(now())
   plants    Plant[]
 }
@@ -53,6 +55,10 @@ model Photo {
   plantId     String
   objectKey   String   @unique
   url         String
+  // thumbnail version of the image used in grids
+  thumbnailUrl     String?
+  thumbnailWidth   Int?
+  thumbnailHeight  Int?
   contentType String?
   width       Int?
   height      Int?

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -8,10 +8,23 @@ export const runtime = 'nodejs';
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { plantId, objectKey, url, contentType, width, height } = body;
+    const {
+      plantId,
+      objectKey,
+      url,
+      contentType,
+      width,
+      height,
+      thumbnailUrl,
+      thumbnailWidth,
+      thumbnailHeight,
+    } = body;
 
     if (!plantId || !objectKey || !url) {
-      return NextResponse.json({ error: 'plantId, objectKey, and url are required' }, { status: 400 });
+      return NextResponse.json(
+        { error: 'plantId, objectKey, and url are required' },
+        { status: 400 }
+      );
     }
 
     const photo = await prisma.photo.create({
@@ -22,6 +35,9 @@ export async function POST(req: NextRequest) {
         contentType: contentType || undefined,
         width: width ?? undefined,
         height: height ?? undefined,
+        thumbnailUrl: thumbnailUrl ?? undefined,
+        thumbnailWidth: thumbnailWidth ?? undefined,
+        thumbnailHeight: thumbnailHeight ?? undefined,
       },
     });
 

--- a/src/app/api/rooms/reorder/route.ts
+++ b/src/app/api/rooms/reorder/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const order: { id: string; sortOrder: number }[] = body.order || [];
+    for (const { id, sortOrder } of order) {
+      await prisma.room.update({ where: { id }, data: { sortOrder } });
+    }
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -1,13 +1,21 @@
-import { NextResponse } from 'next/server'
-import { prisma } from '@/lib/db'
-import { z } from 'zod'
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { z } from 'zod';
 
-export async function GET() { const rooms = await prisma.room.findMany({ orderBy: { createdAt: 'desc' } }); return NextResponse.json(rooms) }
+export async function GET() {
+  const rooms = await prisma.room.findMany({ orderBy: { sortOrder: 'asc' } });
+  return NextResponse.json(rooms);
+}
 
 const schema = z.object({ name: z.string().min(1) })
 export async function POST(req: Request) {
-  const json = await req.json(); const parsed = schema.safeParse(json)
-  if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
-  const room = await prisma.room.create({ data: { name: parsed.data.name } })
-  return NextResponse.json(room, { status: 201 })
+  const json = await req.json();
+  const parsed = schema.safeParse(json);
+  if (!parsed.success)
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  const count = await prisma.room.count();
+  const room = await prisma.room.create({
+    data: { name: parsed.data.name, sortOrder: count },
+  });
+  return NextResponse.json(room, { status: 201 });
 }

--- a/src/app/plants/[id]/events.csv/route.ts
+++ b/src/app/plants/[id]/events.csv/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest } from 'next/server';
+import { prisma } from '@/lib/db';
+import { CareType } from '@prisma/client';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const { searchParams } = new URL(req.url);
+  const type = searchParams.get('type') as CareType | null;
+  const events = await prisma.careEvent.findMany({
+    where: { plantId: params.id, ...(type ? { type } : {}) },
+    orderBy: { createdAt: 'desc' },
+  });
+  const rows = [
+    ['id', 'type', 'amountMl', 'note', 'createdAt'],
+    ...events.map((e) => [
+      e.id,
+      e.type,
+      e.amountMl ?? '',
+      e.note ?? '',
+      e.createdAt.toISOString(),
+    ]),
+  ];
+  const csv = rows
+    .map((r) => r.map((v) => `"${String(v).replace(/"/g, '""')}"`).join(','))
+    .join('\n');
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="plant-${params.id}-events.csv"`,
+    },
+  });
+}

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -1,16 +1,30 @@
-import { prisma } from '@/lib/db'
-import Image from 'next/image'
-import CareButtons from '@/components/CareButtons'
-import { format } from 'date-fns'
+import { prisma } from '@/lib/db';
+import Image from 'next/image';
+import CareButtons from '@/components/CareButtons';
+import { format } from 'date-fns';
+import { CareType } from '@prisma/client';
 
-export const dynamic = 'force-dynamic'
+export const dynamic = 'force-dynamic';
 
-export default async function PlantDetail({ params }: { params: { id: string } }) {
+export default async function PlantDetail({
+  params,
+  searchParams,
+}: {
+  params: { id: string };
+  searchParams: { type?: string };
+}) {
+  const type = searchParams.type as CareType | undefined;
   const plant = await prisma.plant.findUnique({
     where: { id: params.id },
-    include: { photos: true, events: { orderBy: { createdAt: 'desc' } } },
-  })
-  if (!plant) return <div className="card">Plant not found</div>
+    include: {
+      photos: true,
+      events: {
+        where: type ? { type } : undefined,
+        orderBy: { createdAt: 'desc' },
+      },
+    },
+  });
+  if (!plant) return <div className="card">Plant not found</div>;
 
   const cover =
     (plant.coverPhotoId && plant.photos.find((p) => p.id === plant.coverPhotoId)) ??
@@ -34,13 +48,45 @@ export default async function PlantDetail({ params }: { params: { id: string } }
       </section>
 
       <section className="card">
-        <h3 className="text-lg font-semibold mb-3">History</h3>
+        <div className="flex items-center mb-3 gap-2">
+          <h3 className="text-lg font-semibold">History</h3>
+          <form method="get" className="ml-auto flex items-center gap-2 text-sm">
+            <label htmlFor="type" className="sr-only">
+              Filter by type
+            </label>
+            <select
+              id="type"
+              name="type"
+              defaultValue={type ?? ''}
+              className="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-xs"
+            >
+              <option value="">All</option>
+              {Object.values(CareType).map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+            <button type="submit" className="rounded bg-slate-700 px-2 py-1 text-xs text-white">
+              Apply
+            </button>
+          </form>
+          <a
+            href={`/plants/${plant.id}/events.csv${type ? `?type=${type}` : ''}`}
+            className="rounded bg-emerald-600 px-2 py-1 text-xs text-white"
+          >
+            Export CSV
+          </a>
+        </div>
         {plant.events.length === 0 ? (
           <p>No care events yet.</p>
         ) : (
           <ul className="space-y-2">
             {plant.events.map((ev) => (
-              <li key={ev.id} className="border-b border-slate-800 pb-2 last:border-b-0 last:pb-0">
+              <li
+                key={ev.id}
+                className="border-b border-slate-800 pb-2 last:border-b-0 last:pb-0"
+              >
                 <div className="flex justify-between text-sm">
                   <span className="font-medium">{ev.type}</span>
                   <span>{format(ev.createdAt, 'PPP')}</span>
@@ -52,5 +98,5 @@ export default async function PlantDetail({ params }: { params: { id: string } }
         )}
       </section>
     </div>
-  )
+  );
 }

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -1,17 +1,120 @@
-import { prisma } from '@/lib/db'
-import PlantForm from '@/components/PlantForm'
-import PlantCard from '@/components/PlantCard'
-export const dynamic = 'force-dynamic'
-export default async function PlantsPage() {
-  const plants = await prisma.plant.findMany({ include: { photos: true, room: true }, orderBy: { createdAt: 'desc' } })
+import { prisma } from '@/lib/db';
+import PlantForm from '@/components/PlantForm';
+import PlantCard from '@/components/PlantCard';
+import { LightLevel } from '@prisma/client';
+import { addDays, isBefore } from 'date-fns';
+
+export const dynamic = 'force-dynamic';
+export default async function PlantsPage({
+  searchParams,
+}: {
+  searchParams: {
+    q?: string;
+    room?: string;
+    light?: string;
+    overdue?: string;
+  };
+}) {
+  const rooms = await prisma.room.findMany({ orderBy: { name: 'asc' } });
+  const { q, room, light, overdue } = searchParams;
+  const where: any = {};
+  if (q) {
+    where.OR = [
+      { name: { contains: q, mode: 'insensitive' } },
+      { commonName: { contains: q, mode: 'insensitive' } },
+      { species: { contains: q, mode: 'insensitive' } },
+    ];
+  }
+  if (room) where.roomId = room;
+  if (light) where.lightLevel = light;
+  const plantsAll = await prisma.plant.findMany({
+    where,
+    include: { photos: true, room: true },
+    orderBy: { createdAt: 'desc' },
+  });
+  let plants = plantsAll;
+  if (overdue === '1') {
+    const now = new Date();
+    plants = plantsAll.filter((p) => {
+      const waterDue = p.lastWateredAt
+        ? addDays(p.lastWateredAt, p.wateringIntervalDays)
+        : null;
+      const fertDue = p.lastFertilizedAt
+        ? addDays(p.lastFertilizedAt, p.fertilizingIntervalDays)
+        : null;
+      return (
+        (waterDue && isBefore(waterDue, now)) ||
+        (fertDue && isBefore(fertDue, now))
+      );
+    });
+  }
   return (
     <div className="space-y-6">
-      <section className="card"><h2 className="text-lg font-semibold mb-4">Add a plant</h2><PlantForm /></section>
-      <section className="card"><h2 className="text-lg font-semibold mb-3">My plants</h2>
+      <section className="card">
+        <h2 className="text-lg font-semibold mb-4">Add a plant</h2>
+        <PlantForm />
+      </section>
+      <section className="card">
+        <h2 className="text-lg font-semibold mb-3">My plants</h2>
+        <form method="get" className="mb-4 grid gap-2 sm:grid-cols-2 md:grid-cols-4 text-sm">
+          <input
+            name="q"
+            defaultValue={q ?? ''}
+            placeholder="Search"
+            aria-label="Search plants"
+            className="border border-slate-700 rounded px-2 py-1 bg-slate-800"
+          />
+          <select
+            name="room"
+            defaultValue={room ?? ''}
+            aria-label="Filter by room"
+            className="border border-slate-700 rounded px-2 py-1 bg-slate-800"
+          >
+            <option value="">All rooms</option>
+            {rooms.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.name}
+              </option>
+            ))}
+          </select>
+          <select
+            name="light"
+            defaultValue={light ?? ''}
+            aria-label="Filter by light level"
+            className="border border-slate-700 rounded px-2 py-1 bg-slate-800"
+          >
+            <option value="">All light</option>
+            {Object.values(LightLevel).map((l) => (
+              <option key={l} value={l}>
+                {l}
+              </option>
+            ))}
+          </select>
+          <label className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              name="overdue"
+              value="1"
+              defaultChecked={overdue === '1'}
+              aria-label="Overdue care"
+            />
+            Overdue care
+          </label>
+          <div className="sm:col-span-2 md:col-span-1 flex items-center justify-end">
+            <button
+              className="rounded bg-slate-700 text-white px-3 py-1 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              type="submit"
+            >
+              Apply
+            </button>
+          </div>
+        </form>
         <ul className="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
-          {plants.map((p) => (<PlantCard key={p.id} plant={p} />))}
+          {plants.map((p) => (
+            <PlantCard key={p.id} plant={p} />
+          ))}
         </ul>
       </section>
     </div>
-  )
+  );
 }

--- a/src/app/rooms/page.tsx
+++ b/src/app/rooms/page.tsx
@@ -1,22 +1,22 @@
-import { prisma } from '@/lib/db'
-import RoomForm from '@/components/RoomForm'
-export const dynamic = 'force-dynamic'
+import { prisma } from '@/lib/db';
+import RoomForm from '@/components/RoomForm';
+import RoomsList from '@/components/RoomsList';
+export const dynamic = 'force-dynamic';
 export default async function RoomsPage() {
-  const rooms = await prisma.room.findMany({ include: { plants: true }, orderBy: { createdAt: 'desc' } })
+  const rooms = await prisma.room.findMany({
+    include: { plants: true },
+    orderBy: { sortOrder: 'asc' },
+  });
   return (
     <div className="space-y-6">
-      <section className="card"><h2 className="text-lg font-semibold mb-4">Add a room</h2><RoomForm /></section>
+      <section className="card">
+        <h2 className="text-lg font-semibold mb-4">Add a room</h2>
+        <RoomForm />
+      </section>
       <section className="card">
         <h2 className="text-lg font-semibold mb-3">Rooms</h2>
-        <ul className="grid sm:grid-cols-2 gap-4">
-          {rooms.map(r => (
-            <li key={r.id} className="border border-slate-200 dark:border-slate-800 rounded-xl p-3">
-              <div className="font-medium">{r.name}</div>
-              <div className="text-sm text-slate-600 dark:text-slate-400">{r.plants.length} plants</div>
-            </li>
-          ))}
-        </ul>
+        <RoomsList rooms={rooms} />
       </section>
     </div>
-  )
+  );
 }

--- a/src/components/PlantCard.tsx
+++ b/src/components/PlantCard.tsx
@@ -37,9 +37,9 @@ export default function PlantCard({ plant }: { plant: PlantWithPhotos }) {
         {cover ? (
           <Image
             alt={plant.name}
-            src={cover.url}
-            width={cover.width ?? 800}
-            height={cover.height ?? 600}
+            src={cover.thumbnailUrl || cover.url}
+            width={cover.thumbnailWidth ?? cover.width ?? 800}
+            height={cover.thumbnailHeight ?? cover.height ?? 600}
             className="h-full w-full object-cover"
             priority={false}
           />
@@ -54,14 +54,17 @@ export default function PlantCard({ plant }: { plant: PlantWithPhotos }) {
             <div key={p.id} className="relative group">
               <Image
                 alt="thumb"
-                src={p.url}
-                width={p.width ?? 400}
-                height={p.height ?? 300}
+                src={p.thumbnailUrl || p.url}
+                width={p.thumbnailWidth ?? p.width ?? 400}
+                height={p.thumbnailHeight ?? p.height ?? 300}
                 className="h-24 w-full object-cover rounded border border-slate-800"
               />
               <div className="absolute inset-0 hidden group-hover:flex items-end justify-between p-1 bg-black/30 rounded">
                 <button
-                  className={`text-[11px] px-2 py-0.5 rounded ${
+                  aria-label={
+                    plant.coverPhotoId === p.id ? 'Cover photo' : 'Set as cover photo'
+                  }
+                  className={`text-[11px] px-2 py-0.5 rounded focus:outline-none focus:ring-2 focus:ring-emerald-500 ${
                     plant.coverPhotoId === p.id ? 'bg-emerald-600' : 'bg-slate-700 hover:bg-slate-600'
                   } text-white`}
                   onClick={async () => {
@@ -77,7 +80,8 @@ export default function PlantCard({ plant }: { plant: PlantWithPhotos }) {
                 </button>
 
                 <button
-                  className="text-[11px] px-2 py-0.5 rounded bg-red-600 hover:bg-red-500 text-white"
+                  aria-label="Delete photo"
+                  className="text-[11px] px-2 py-0.5 rounded bg-red-600 hover:bg-red-500 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
                   onClick={async () => {
                     await fetch(`/api/photos/${p.id}`, { method: 'DELETE' });
                     router.refresh();

--- a/src/components/RoomsList.tsx
+++ b/src/components/RoomsList.tsx
@@ -1,0 +1,52 @@
+'use client';
+import { useState } from 'react';
+import type { Room, Plant } from '@prisma/client';
+
+type RoomWithPlants = Room & { plants: Plant[] };
+
+export default function RoomsList({ rooms }: { rooms: RoomWithPlants[] }) {
+  const [items, setItems] = useState(rooms);
+  const [dragId, setDragId] = useState<string | null>(null);
+
+  const onDragStart = (id: string) => () => setDragId(id);
+  const onDragOver = (id: string) => (e: React.DragEvent) => {
+    e.preventDefault();
+    if (dragId === id) return;
+    const dragIndex = items.findIndex((r) => r.id === dragId);
+    const overIndex = items.findIndex((r) => r.id === id);
+    const newItems = [...items];
+    const [moved] = newItems.splice(dragIndex, 1);
+    newItems.splice(overIndex, 0, moved);
+    setItems(newItems);
+  };
+  const onDragEnd = async () => {
+    setDragId(null);
+    await fetch('/api/rooms/reorder', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ order: items.map((r, idx) => ({ id: r.id, sortOrder: idx })) }),
+    });
+  };
+
+  return (
+    <ul className="grid sm:grid-cols-2 gap-4">
+      {items.map((r) => (
+        <li
+          key={r.id}
+          draggable
+          onDragStart={onDragStart(r.id)}
+          onDragOver={onDragOver(r.id)}
+          onDragEnd={onDragEnd}
+          tabIndex={0}
+          aria-label={`Room ${r.name}`}
+          className="border border-slate-200 dark:border-slate-800 rounded-xl p-3 flex items-center justify-between focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        >
+          <span>{r.name}</span>
+          <span className="ml-2 rounded-full bg-slate-700 text-white text-xs px-2 py-0.5" aria-label="plant count">
+            {r.plants.length}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/UploadWidget.tsx
+++ b/src/components/UploadWidget.tsx
@@ -97,7 +97,8 @@ export default function UploadWidget({ plantId }: Props) {
       />
       <button
         type="button"
-        className="rounded bg-slate-700 hover:bg-slate-600 text-white px-3 py-1 text-sm disabled:opacity-50"
+        aria-label="Upload photos"
+        className="rounded bg-slate-700 hover:bg-slate-600 text-white px-3 py-1 text-sm disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         onClick={pick}
         disabled={uploading}
       >
@@ -134,25 +135,37 @@ export default function UploadWidget({ plantId }: Props) {
 
   async function handleFile(file: File, onProgress: (p: number) => void) {
     // 1) Resize + auto-rotate using createImageBitmap + canvas
+    // resize original to a max of 800px
     const { blob, width, height, outType } = await resize(file, {
-      max: 1600,
+      max: 800,
       quality: 0.85,
     });
+    // generate a smaller thumbnail (200px)
+    const thumb = await resize(file, { max: 200, quality: 0.7 });
 
     // 2) Create object key & presign
     const ext = outType === 'image/png' ? 'png' : 'jpg';
-    const objectKey = `plants/${plantId}/${Date.now()}-${crypto.randomUUID()}.${ext}`;
+    const baseKey = `plants/${plantId}/${Date.now()}-${crypto.randomUUID()}`;
+    const objectKey = `${baseKey}.${ext}`;
+    const thumbKey = `${baseKey}-thumb.${ext}`;
 
     const presign = await fetch('/api/uploads/presign', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ objectKey, contentType: outType }),
     }).then((r) => r.json());
-
     if (!presign?.uploadUrl) throw new Error(presign?.error ?? 'presign failed');
+
+    const presignThumb = await fetch('/api/uploads/presign', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ objectKey: thumbKey, contentType: outType }),
+    }).then((r) => r.json());
+    if (!presignThumb?.uploadUrl) throw new Error(presignThumb?.error ?? 'presign failed');
 
     // 3) Upload with XHR so we can show progress
     await xhrPut(presign.uploadUrl, blob, outType, onProgress);
+    await xhrPut(presignThumb.uploadUrl, thumb.blob, outType, () => {});
 
     // 4) Save Photo row
     const create = await fetch('/api/photos', {
@@ -165,6 +178,9 @@ export default function UploadWidget({ plantId }: Props) {
         contentType: outType,
         width,
         height,
+        thumbnailUrl: presignThumb.publicUrl,
+        thumbnailWidth: thumb.width,
+        thumbnailHeight: thumb.height,
       }),
     }).then((r) => r.json());
 


### PR DESCRIPTION
## Summary
- resize uploads to 800px and generate 200px thumbnails
- add per-plant care event timeline with CSV export
- enable drag-and-drop room ordering with plant count badges
- add plant search and filtering UI with URL-encoded params
- improve accessibility with ARIA labels and focus rings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx --yes @axe-core/cli https://example.com` *(no output)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895ac597ab0832499f6981e73321279