### PR TITLE
Improve upload UX with validation and error handling

### DIFF
--- a/src/components/UploadWidget.tsx
+++ b/src/components/UploadWidget.tsx
@@ -32,14 +32,18 @@ export default function UploadWidget({ plantId }: Props) {
     const files = e.target.files;
     if (!files?.length) return;
 
+    const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+    const ACCEPTED = ['image/jpeg', 'image/png'];
+
     const valid: File[] = [];
     const list: Item[] = [];
+
     Array.from(files).forEach((f) => {
-      if (!f.type.startsWith('image/')) {
-        showToast('Unsupported file type');
+      if (!ACCEPTED.includes(f.type)) {
+        showToast('Unsupported file type. Use JPG or PNG');
         return;
       }
-      if (f.size > 5 * 1024 * 1024) {
+      if (f.size > MAX_SIZE) {
         showToast('File too large (max 5MB)');
         return;
       }
@@ -90,17 +94,38 @@ export default function UploadWidget({ plantId }: Props) {
       <input
         ref={inputRef}
         type="file"
-        accept="image/*"
+        accept="image/jpeg,image/png"
         multiple
         hidden
         onChange={onPick}
       />
       <button
         type="button"
-        className="rounded bg-slate-700 hover:bg-slate-600 text-white px-3 py-1 text-sm disabled:opacity-50"
+        className="rounded bg-slate-700 hover:bg-slate-600 text-white px-3 py-1 text-sm disabled:opacity-50 flex items-center gap-2"
         onClick={pick}
         disabled={uploading}
       >
+        {uploading && (
+          <svg
+            className="h-4 w-4 animate-spin"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8v4l3-3-3-3v4a12 12 0 00-12 12h4z"
+            />
+          </svg>
+        )}
         {uploading ? 'Uploading…' : 'Upload photos'}
       </button>
 
@@ -109,6 +134,27 @@ export default function UploadWidget({ plantId }: Props) {
           {items.map((it, idx) => (
             <div key={idx} className="text-xs text-slate-300">
               <div className="flex items-center gap-2">
+                {it.status === 'uploading' && (
+                  <svg
+                    className="h-3 w-3 animate-spin"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8v4l3-3-3-3v4a12 12 0 00-12 12h4z"
+                    />
+                  </svg>
+                )}
                 <span className="truncate">{it.name}</span>
                 <span className="ml-auto">{it.progress}%</span>
               </div>
@@ -125,7 +171,10 @@ export default function UploadWidget({ plantId }: Props) {
       )}
 
       {toast && (
-        <div className="fixed bottom-4 right-4 bg-red-600 text-white px-3 py-2 rounded">
+        <div
+          role="alert"
+          className="fixed bottom-4 right-4 bg-red-600 text-white px-3 py-2 rounded"
+        >
           {toast}
         </div>
       )}
@@ -202,8 +251,16 @@ function xhrPut(url: string, blob: Blob, contentType: string, onProgress: (p: nu
     xhr.upload.onprogress = (e) => {
       if (e.lengthComputable) onProgress(Math.round((e.loaded / e.total) * 100));
     };
-    xhr.onerror = () => reject(new Error('network error'));
-    xhr.onload = () => (xhr.status >= 200 && xhr.status < 300 ? resolve() : reject(new Error(String(xhr.status))));
+    xhr.onerror = () => reject(new Error('Network error'));
+    xhr.ontimeout = () => reject(new Error('Upload timed out'));
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve();
+      } else {
+        reject(new Error(`Upload failed (R2 error ${xhr.status})`));
+      }
+    };
+    xhr.timeout = 60_000; // 60s
     xhr.open('PUT', url);
     xhr.setRequestHeader('Content-Type', contentType);
     xhr.send(blob);


### PR DESCRIPTION
## Summary
- validate image type and size before upload
- show spinner indicators during upload
- surface friendly errors for timeouts or failed R2 uploads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6895e984f03c8324bcb5ab96d4c4581c