### PR TITLE
Add per-plant care history and CSV export

### DIFF
--- a/src/app/api/plants/[id]/events.csv/route.ts
+++ b/src/app/api/plants/[id]/events.csv/route.ts
@@ -1,0 +1,40 @@
+import { prisma } from '@/lib/db'
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const events = await prisma.careEvent.findMany({
+    where: { plantId: params.id },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  const headers = new Headers({
+    'Content-Type': 'text/csv',
+    'Content-Disposition': `attachment; filename="plant-${params.id}-events.csv"`,
+  })
+
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode('id,type,amountMl,note,tempC,humidity,precipMm,lat,lon,createdAt\n')
+      )
+      for (const ev of events) {
+        const row = [
+          ev.id,
+          ev.type,
+          ev.amountMl ?? '',
+          ev.note ? `"${ev.note.replace(/"/g, '""')}"` : '',
+          ev.tempC ?? '',
+          ev.humidity ?? '',
+          ev.precipMm ?? '',
+          ev.lat ?? '',
+          ev.lon ?? '',
+          ev.createdAt.toISOString(),
+        ].join(',')
+        controller.enqueue(encoder.encode(row + '\n'))
+      }
+      controller.close()
+    },
+  })
+
+  return new Response(stream, { headers })
+}

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/db'
 import Image from 'next/image'
 import CareButtons from '@/components/CareButtons'
-import { format } from 'date-fns'
+import CareTimeline from '@/components/CareTimeline'
 
 export const dynamic = 'force-dynamic'
 
@@ -34,22 +34,23 @@ export default async function PlantDetail({ params }: { params: { id: string } }
       </section>
 
       <section className="card">
-        <h3 className="text-lg font-semibold mb-3">History</h3>
-        {plant.events.length === 0 ? (
-          <p>No care events yet.</p>
-        ) : (
-          <ul className="space-y-2">
-            {plant.events.map((ev) => (
-              <li key={ev.id} className="border-b border-slate-800 pb-2 last:border-b-0 last:pb-0">
-                <div className="flex justify-between text-sm">
-                  <span className="font-medium">{ev.type}</span>
-                  <span>{format(ev.createdAt, 'PPP')}</span>
-                </div>
-                {ev.note && <div className="text-xs text-slate-400">{ev.note}</div>}
-              </li>
-            ))}
-          </ul>
-        )}
+        <div className="flex justify-between items-center mb-3">
+          <h3 className="text-lg font-semibold">History</h3>
+          <a
+            href={`/api/plants/${plant.id}/events.csv`}
+            className="btn btn-sm"
+          >
+            Export CSV
+          </a>
+        </div>
+        <CareTimeline
+          events={plant.events.map((ev) => ({
+            id: ev.id,
+            type: ev.type,
+            note: ev.note,
+            createdAt: ev.createdAt.toISOString(),
+          }))}
+        />
       </section>
     </div>
   )

--- a/src/components/CareTimeline.tsx
+++ b/src/components/CareTimeline.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useState } from 'react'
+import type { CareType } from '@prisma/client'
+import { format } from 'date-fns'
+
+const careTypes: CareType[] = ['WATER', 'FERTILIZE', 'PRUNE', 'REPOT', 'NOTE']
+
+type Event = {
+  id: string
+  type: CareType
+  note: string | null
+  createdAt: string
+}
+
+export default function CareTimeline({ events }: { events: Event[] }) {
+  const [filter, setFilter] = useState<CareType | 'ALL'>('ALL')
+  const filtered = filter === 'ALL' ? events : events.filter((e) => e.type === filter)
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-2 mb-3">
+        <button
+          className={`btn btn-sm ${filter === 'ALL' ? 'btn-primary' : ''}`}
+          onClick={() => setFilter('ALL')}
+        >
+          All
+        </button>
+        {careTypes.map((t) => (
+          <button
+            key={t}
+            className={`btn btn-sm ${filter === t ? 'btn-primary' : ''}`}
+            onClick={() => setFilter(t)}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      {filtered.length === 0 ? (
+        <p>No care events yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {filtered.map((ev) => (
+            <li
+              key={ev.id}
+              className="border-b border-slate-800 pb-2 last:border-b-0 last:pb-0"
+            >
+              <div className="flex justify-between text-sm">
+                <span className="font-medium">{ev.type}</span>
+                <span>{format(new Date(ev.createdAt), 'PPP')}</span>
+              </div>
+              {ev.note && <div className="text-xs text-slate-400">{ev.note}</div>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add filterable care event timeline component
- wire plant detail page to show timeline and CSV export button
- implement API route to stream care events as CSV

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895ebfce768832484582cb7f74c5085