### PR TITLE
Add drag-and-drop room reordering with plant count badges

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,7 @@ datasource db {
 model Room {
   id        String   @id @default(cuid())
   name      String
+  sortOrder Int      @default(0)
   createdAt DateTime @default(now())
   plants    Plant[]
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -6,7 +6,7 @@ async function main() {
   const living = await prisma.room.upsert({
     where: { id: 'seed-living' },
     update: {},
-    create: { id: 'seed-living', name: 'Living Room' },
+    create: { id: 'seed-living', name: 'Living Room', sortOrder: 0 },
   });
 
   // Plants

--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -2,12 +2,28 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { z } from 'zod'
 
-export async function GET() { const rooms = await prisma.room.findMany({ orderBy: { createdAt: 'desc' } }); return NextResponse.json(rooms) }
+export async function GET() {
+  const rooms = await prisma.room.findMany({ orderBy: { sortOrder: 'asc' } })
+  return NextResponse.json(rooms)
+}
 
 const schema = z.object({ name: z.string().min(1) })
 export async function POST(req: Request) {
   const json = await req.json(); const parsed = schema.safeParse(json)
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
-  const room = await prisma.room.create({ data: { name: parsed.data.name } })
+  const count = await prisma.room.count()
+  const room = await prisma.room.create({ data: { name: parsed.data.name, sortOrder: count } })
   return NextResponse.json(room, { status: 201 })
+}
+
+const orderSchema = z.object({ order: z.array(z.object({ id: z.string(), sortOrder: z.number() })) })
+export async function PUT(req: Request) {
+  const json = await req.json(); const parsed = orderSchema.safeParse(json)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+  await prisma.$transaction(
+    parsed.data.order.map((r) =>
+      prisma.room.update({ where: { id: r.id }, data: { sortOrder: r.sortOrder } })
+    )
+  )
+  return NextResponse.json({ status: 'ok' })
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,3 +8,4 @@ body { @apply bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100; }
 .input { @apply w-full rounded-xl border border-slate-300 dark:border-slate-700 px-3 py-2 bg-white dark:bg-slate-900; }
 .label { @apply text-sm font-medium text-slate-600 dark:text-slate-300; }
 .row { @apply flex items-center justify-between gap-4; }
+.badge { @apply inline-flex items-center justify-center rounded-full bg-slate-200 dark:bg-slate-800 text-xs px-2 py-0.5; }

--- a/src/app/rooms/page.tsx
+++ b/src/app/rooms/page.tsx
@@ -1,21 +1,15 @@
 import { prisma } from '@/lib/db'
 import RoomForm from '@/components/RoomForm'
+import RoomsList from '@/components/RoomsList'
 export const dynamic = 'force-dynamic'
 export default async function RoomsPage() {
-  const rooms = await prisma.room.findMany({ include: { plants: true }, orderBy: { createdAt: 'desc' } })
+  const rooms = await prisma.room.findMany({ include: { plants: true }, orderBy: { sortOrder: 'asc' } })
   return (
     <div className="space-y-6">
       <section className="card"><h2 className="text-lg font-semibold mb-4">Add a room</h2><RoomForm /></section>
       <section className="card">
         <h2 className="text-lg font-semibold mb-3">Rooms</h2>
-        <ul className="grid sm:grid-cols-2 gap-4">
-          {rooms.map(r => (
-            <li key={r.id} className="border border-slate-200 dark:border-slate-800 rounded-xl p-3">
-              <div className="font-medium">{r.name}</div>
-              <div className="text-sm text-slate-600 dark:text-slate-400">{r.plants.length} plants</div>
-            </li>
-          ))}
-        </ul>
+        <RoomsList rooms={rooms} />
       </section>
     </div>
   )

--- a/src/components/RoomsList.tsx
+++ b/src/components/RoomsList.tsx
@@ -1,0 +1,50 @@
+'use client'
+import { useState } from 'react'
+import type { Room, Plant } from '@prisma/client'
+
+interface RoomWithPlants extends Room {
+  plants: Plant[]
+}
+
+export default function RoomsList({ rooms }: { rooms: RoomWithPlants[] }) {
+  const [items, setItems] = useState(rooms)
+  const handleDragStart = (e: React.DragEvent<HTMLLIElement>, index: number) => {
+    e.dataTransfer.setData('text/plain', index.toString())
+  }
+  const handleDragOver = (e: React.DragEvent<HTMLLIElement>) => {
+    e.preventDefault()
+  }
+  const handleDrop = async (e: React.DragEvent<HTMLLIElement>, index: number) => {
+    e.preventDefault()
+    const from = Number(e.dataTransfer.getData('text/plain'))
+    if (Number.isNaN(from) || from === index) return
+    const updated = Array.from(items)
+    const [moved] = updated.splice(from, 1)
+    updated.splice(index, 0, moved)
+    setItems(updated)
+    await fetch('/api/rooms', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ order: updated.map((r, i) => ({ id: r.id, sortOrder: i })) }),
+    })
+  }
+  return (
+    <ul className="grid sm:grid-cols-2 gap-4">
+      {items.map((r, idx) => (
+        <li
+          key={r.id}
+          draggable
+          onDragStart={(e) => handleDragStart(e, idx)}
+          onDragOver={handleDragOver}
+          onDrop={(e) => handleDrop(e, idx)}
+          className="border border-slate-200 dark:border-slate-800 rounded-xl p-3 cursor-move"
+        >
+          <div className="flex items-center justify-between">
+            <div className="font-medium">{r.name}</div>
+            <span className="badge">{r.plants.length}</span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `sortOrder` to rooms and seed initial value
- Allow updating room order via PUT `/api/rooms`
- Show room plant counts as badges and support drag-reorder UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895ec0ada40832494c78e38dc7ac5c9