### PR TITLE
feat: add backup and import endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Photo uploads to Cloudflare R2 (presigned PUT)
 
 Weather snapshot defaults (optional lat/lon)
 
+Full backup/restore via JSON and CSV care event import
+
 Quick start
 1) Prereqs
 Node 18+ (or 20+)

--- a/src/app/api/backup/route.ts
+++ b/src/app/api/backup/route.ts
@@ -1,0 +1,41 @@
+import { prisma } from '@/lib/db'
+
+export async function GET() {
+  const [rooms, plants, photos, careEvents, species] = await Promise.all([
+    prisma.room.findMany(),
+    prisma.plant.findMany(),
+    prisma.photo.findMany(),
+    prisma.careEvent.findMany(),
+    prisma.species.findMany(),
+  ])
+
+  const data = { rooms, plants, photos, careEvents, species }
+
+  return new Response(JSON.stringify(data), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Disposition': 'attachment; filename="backup.json"',
+    },
+  })
+}
+
+export async function POST(req: Request) {
+  const data = await req.json()
+
+  await prisma.$transaction([
+    prisma.careEvent.deleteMany(),
+    prisma.photo.deleteMany(),
+    prisma.plant.deleteMany(),
+    prisma.room.deleteMany(),
+    prisma.species.deleteMany(),
+  ])
+
+  if (data.species?.length) await prisma.species.createMany({ data: data.species })
+  if (data.rooms?.length) await prisma.room.createMany({ data: data.rooms })
+  if (data.plants?.length) await prisma.plant.createMany({ data: data.plants })
+  if (data.photos?.length) await prisma.photo.createMany({ data: data.photos })
+  if (data.careEvents?.length)
+    await prisma.careEvent.createMany({ data: data.careEvents })
+
+  return Response.json({ ok: true })
+}

--- a/src/app/api/plants/[id]/events.csv/route.ts
+++ b/src/app/api/plants/[id]/events.csv/route.ts
@@ -1,5 +1,18 @@
 import { prisma } from '@/lib/db'
 
+function parseCsv(text: string) {
+  const lines = text.trim().split(/\r?\n/)
+  const headers = lines[0].split(',')
+  return lines.slice(1).map((line) => {
+    const values = line.split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/)
+    const record: Record<string, string> = {}
+    headers.forEach((h, i) => {
+      record[h] = values[i]?.replace(/^"|"$/g, '').replace(/""/g, '"')
+    })
+    return record
+  })
+}
+
 export async function GET(_: Request, { params }: { params: { id: string } }) {
   const events = await prisma.careEvent.findMany({
     where: { plantId: params.id },
@@ -37,4 +50,38 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
   })
 
   return new Response(stream, { headers })
+}
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const { csv, mapping = {} } = await req.json()
+  const rows = parseCsv(csv)
+
+  const events = rows.map((row) => {
+    const ev: any = { plantId: params.id }
+    for (const [col, value] of Object.entries(row)) {
+      const field = (mapping as Record<string, string>)[col] ?? col
+      if (!value) continue
+      switch (field) {
+        case 'amountMl':
+          ev.amountMl = parseInt(value, 10)
+          break
+        case 'tempC':
+        case 'humidity':
+        case 'precipMm':
+        case 'lat':
+        case 'lon':
+          ev[field] = parseFloat(value)
+          break
+        case 'createdAt':
+          ev.createdAt = new Date(value)
+          break
+        default:
+          ev[field] = value
+      }
+    }
+    return ev
+  })
+
+  if (events.length) await prisma.careEvent.createMany({ data: events })
+  return Response.json({ imported: events.length })
 }

--- a/src/app/api/uploads/route.ts
+++ b/src/app/api/uploads/route.ts
@@ -53,6 +53,7 @@ export async function POST(req: NextRequest) {
         plantId,
         objectKey: key,
         url,
+        thumbUrl: url,
         contentType: file.type || undefined,
       },
     });


### PR DESCRIPTION
## Summary
- add /api/backup endpoint for full JSON backup/restore
- allow CSV care event imports with column mapping
- fix upload route missing thumbUrl

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6895ee39f20483248696456fec1f8ef0