### PR TITLE
Add calendar view for task filtering

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,8 @@
 import { prisma } from '@/lib/db'
 import TaskRow from '@/components/TaskRow'
 import { format } from 'date-fns'
-import { computeTaskLists, Task } from '@/lib/tasks'
+import { computeTaskLists } from '@/lib/tasks'
+import TaskCalendar from '@/components/TaskCalendar'
 
 export const dynamic = 'force-dynamic'
 
@@ -10,7 +11,7 @@ export default async function Page() {
     orderBy: { createdAt: 'desc' },
   })
 
-  const { today: due, grouped: groups, groupKeys } = computeTaskLists(plants)
+  const { today: due, grouped: groups, groupKeys } = computeTaskLists(plants, 30)
 
   const upcoming = Object.values(groups).flat()
 
@@ -30,9 +31,14 @@ export default async function Page() {
       </section>
 
       <section className="card">
-        <h2 className="text-lg font-semibold mb-3">Upcoming (next 7 days)</h2>
+        <h2 className="text-lg font-semibold mb-3">Calendar</h2>
+        <TaskCalendar groups={groups} />
+      </section>
+
+      <section className="card">
+        <h2 className="text-lg font-semibold mb-3">Upcoming (next 30 days)</h2>
         {upcoming.length === 0 ? (
-          <p>No upcoming tasks in the next week.</p>
+          <p>No upcoming tasks in the next month.</p>
         ) : (
           <div className="space-y-4">
             {groupKeys.map((k) => (

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  addDays,
+  addMonths,
+  subDays,
+  subMonths,
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  format,
+  isSameMonth,
+} from 'date-fns'
+
+interface CalendarProps {
+  /** Record keyed by yyyy-MM-dd */
+  events?: Record<string, unknown[]>
+  onSelectDate?: (date: Date) => void
+}
+
+export default function Calendar({ events = {}, onSelectDate }: CalendarProps) {
+  const [current, setCurrent] = useState(new Date())
+  const [view, setView] = useState<'month' | 'week'>('month')
+
+  const start =
+    view === 'month'
+      ? startOfWeek(startOfMonth(current))
+      : startOfWeek(current)
+  const end =
+    view === 'month'
+      ? endOfWeek(endOfMonth(current))
+      : endOfWeek(current)
+
+  const days: Date[] = []
+  let day = start
+  while (day <= end) {
+    days.push(day)
+    day = addDays(day, 1)
+  }
+
+  function prev() {
+    setCurrent(view === 'month' ? subMonths(current, 1) : subDays(current, 7))
+  }
+  function next() {
+    setCurrent(view === 'month' ? addMonths(current, 1) : addDays(current, 7))
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <button className="btn btn-xs" onClick={prev}>
+          Prev
+        </button>
+        <div className="font-semibold">
+          {format(current, view === 'month' ? 'MMMM yyyy' : 'PPP')}
+        </div>
+        <button className="btn btn-xs" onClick={next}>
+          Next
+        </button>
+      </div>
+      <div className="grid grid-cols-7 text-center text-xs font-semibold mb-1">
+        {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((d) => (
+          <div key={d}>{d}</div>
+        ))}
+      </div>
+      <div className="grid grid-cols-7 text-sm">
+        {days.map((d) => {
+          const key = format(d, 'yyyy-MM-dd')
+          const hasEvents = Boolean((events[key] || []).length)
+          return (
+            <button
+              key={d.toISOString()}
+              className={`h-16 border p-1 text-left ${
+                view === 'month' && !isSameMonth(d, current)
+                  ? 'text-slate-400'
+                  : ''
+              }`}
+              onClick={() => onSelectDate?.(d)}
+            >
+              <div className="text-xs">{format(d, 'd')}</div>
+              {hasEvents && (
+                <div className="w-1 h-1 rounded-full bg-emerald-500 mt-1 mx-auto"></div>
+              )}
+            </button>
+          )
+        })}
+      </div>
+      <div className="mt-2 text-right">
+        <button
+          className="btn btn-xs"
+          onClick={() => setView(view === 'month' ? 'week' : 'month')}
+        >
+          {view === 'month' ? 'Week view' : 'Month view'}
+        </button>
+      </div>
+    </div>
+  )
+}
+

--- a/src/components/TaskCalendar.tsx
+++ b/src/components/TaskCalendar.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useState } from 'react'
+import { format } from 'date-fns'
+import Calendar from './Calendar'
+import TaskRow from './TaskRow'
+import type { Task } from '@/lib/tasks'
+
+interface Props {
+  groups: Record<string, Task[]>
+}
+
+export default function TaskCalendar({ groups }: Props) {
+  const [selected, setSelected] = useState<Date | null>(null)
+  const key = selected ? format(selected, 'yyyy-MM-dd') : null
+  const tasks = key ? groups[key] ?? [] : []
+
+  return (
+    <div>
+      <Calendar events={groups} onSelectDate={setSelected} />
+      {selected && (
+        <div className="mt-4">
+          <h4 className="font-semibold mb-2">
+            Tasks on {format(selected, 'PPP')}
+          </h4>
+          {tasks.length === 0 ? (
+            <p>No tasks.</p>
+          ) : (
+            <ul className="divide-y divide-slate-200 dark:divide-slate-800">
+              {tasks.map((t) => (
+                <TaskRow key={`${t.kind}-${t.plant.id}`} task={t} />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -4,7 +4,7 @@ import { nextWaterDate, nextFertilizeDate, isDueOrOverdue, isWithinNextDays } fr
 
 export type Task = { kind: 'WATER' | 'FERTILIZE'; due: Date; plant: Plant }
 
-export function computeTaskLists(plants: Plant[]) {
+export function computeTaskLists(plants: Plant[], daysAhead = 7) {
   const allTasks: Task[] = plants.flatMap((p) => [
     { kind: 'WATER' as const, due: nextWaterDate(p), plant: p },
     { kind: 'FERTILIZE' as const, due: nextFertilizeDate(p), plant: p },
@@ -13,7 +13,7 @@ export function computeTaskLists(plants: Plant[]) {
   const today = allTasks.filter((t) => isDueOrOverdue(t.due))
 
   const next = allTasks
-    .filter((t) => isWithinNextDays(t.due, 7))
+    .filter((t) => isWithinNextDays(t.due, daysAhead))
     .sort((a, b) => a.due.getTime() - b.due.getTime())
 
   const grouped = next.reduce<Record<string, Task[]>>((acc, t) => {


### PR DESCRIPTION
## Summary
- add reusable calendar component with month/week toggle and event dots
- include TaskCalendar on home page to filter tasks by date
- allow computeTaskLists to accept days-ahead range

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Type error: Property 'thumbUrl' is missing in type '{ plantId: string; objectKey: string; url: string; contentType: string | undefined; }')

------
https://chatgpt.com/codex/tasks/task_e_6895ee27f1148324b93bc1987de21cdb