### PR TITLE
Filter room queries by user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 dist/
 coverage/
 *.log
+tsconfig.tsbuildinfo
 
 # env & local stuff
 .env

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ npm run start      # Next start
 
 npm run db:push    # Push Prisma schema to DB
 npm run seed       # Seed sample rooms/plants (optional)
+npm test          # Run tests (currently none)
 Project structure (high level)
 bash
 Copy

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -43,7 +43,7 @@ export default async function PlantsPage({ searchParams }: { searchParams: { q?:
 
   const [plantsRaw, rooms] = await Promise.all([
     prisma.plant.findMany({ include: { photos: true, room: true }, where, orderBy: { createdAt: 'desc' } }),
-    prisma.room.findMany({ where: { userId }, orderBy: { name: 'asc' } }),
+    prisma.room.findMany({ where: { plants: { some: { userId } } }, orderBy: { name: 'asc' } }),
   ])
 
   let plants = plantsRaw

--- a/src/app/rooms/page.tsx
+++ b/src/app/rooms/page.tsx
@@ -22,7 +22,11 @@ export default async function RoomsPage() {
   if (!session) redirect('/login')
   const userId = session.user.id
 
-  const rooms = await prisma.room.findMany({ where: { userId }, include: { plants: true }, orderBy: { sortOrder: 'asc' } })
+  const rooms = await prisma.room.findMany({
+    where: { plants: { some: { userId } } },
+    include: { plants: { where: { userId } } },
+    orderBy: { sortOrder: 'asc' },
+  })
   return (
     <div className="space-y-6">
       <section className="card"><h2 className="text-lg font-semibold mb-4">Add a room</h2><RoomForm /></section>


### PR DESCRIPTION
## Summary
- filter room queries via related plants instead of nonexistent `userId`
- document `npm test` script in README
- ignore `tsconfig.tsbuildinfo`

## Testing
- `npx tsc --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895f878213c8324ba3672bda1957d8b