### PR TITLE
Add userId scoping across plant-related models

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,11 +10,14 @@ datasource db {
 
 model Room {
   id        String   @id @default(cuid())
+  userId    String
   name      String
   sortOrder Int      @default(0)
   createdAt DateTime @default(now())
   plants    Plant[]
   shareLinks ShareLink[]
+
+  @@index([userId])
 }
 
 model Plant {
@@ -49,6 +52,8 @@ model Plant {
   shareLinks ShareLink[]
   createdAt DateTime    @default(now())
   updatedAt DateTime    @updatedAt
+
+  @@index([userId])
 }
 
 model Photo {
@@ -63,10 +68,13 @@ model Photo {
   width       Int?
   height      Int?
   createdAt   DateTime @default(now())
+
+  @@index([userId])
 }
 
 model CareEvent {
   id        String   @id @default(cuid())
+  userId    String
   plant     Plant    @relation(fields: [plantId], references: [id])
   plantId   String
   type      CareType
@@ -79,6 +87,8 @@ model CareEvent {
   lon       Float?
   createdAt DateTime @default(now())
   userName  String?
+
+  @@index([userId])
 }
 
 model ShareLink {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,16 +3,16 @@ const prisma = new PrismaClient();
 
 async function main() {
   // Rooms
+  const userId = 'seed-user';
   const living = await prisma.room.upsert({
     where: { id: 'seed-living' },
-    update: {},
-    create: { id: 'seed-living', name: 'Living Room', sortOrder: 0 },
+    update: { userId },
+    create: { id: 'seed-living', userId, name: 'Living Room', sortOrder: 0 },
   });
 
   // Plants
   const now = new Date();
   const fiveDaysAgo = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000);
-  const userId = 'seed-user';
 
   await prisma.plant.createMany({
     data: [

--- a/src/app/api/care-events/route.ts
+++ b/src/app/api/care-events/route.ts
@@ -40,18 +40,21 @@ export async function POST(req: Request) {
   let weather: { tempC: number|null, humidity: number|null, precipMm: number|null } | null = null
   if (!Number.isNaN(lat) && !Number.isNaN(lon)) weather = await fetchWeather(lat, lon)
 
-  const event = await prisma.careEvent.create({ data: {
-    plantId: plant.id,
-    type: parsed.data.type as any,
-    amountMl: parsed.data.amountMl ?? null,
-    note: parsed.data.note ?? null,
-    userName: parsed.data.userName ?? null,
-    tempC: weather?.tempC ?? null,
-    humidity: weather?.humidity ?? null,
-    precipMm: weather?.precipMm ?? null,
-    lat: !Number.isNaN(lat) ? lat : null,
-    lon: !Number.isNaN(lon) ? lon : null,
-  }})
+  const event = await prisma.careEvent.create({
+    data: {
+      plantId: plant.id,
+      userId: user.id,
+      type: parsed.data.type as any,
+      amountMl: parsed.data.amountMl ?? null,
+      note: parsed.data.note ?? null,
+      userName: parsed.data.userName ?? null,
+      tempC: weather?.tempC ?? null,
+      humidity: weather?.humidity ?? null,
+      precipMm: weather?.precipMm ?? null,
+      lat: !Number.isNaN(lat) ? lat : null,
+      lon: !Number.isNaN(lon) ? lon : null,
+    },
+  })
 
   if (parsed.data.type === 'WATER') await prisma.plant.update({ where: { id: plant.id }, data: { lastWateredAt: new Date(), userId: user.id } })
   if (parsed.data.type === 'FERTILIZE') await prisma.plant.update({ where: { id: plant.id }, data: { lastFertilizedAt: new Date(), userId: user.id } })
@@ -66,7 +69,7 @@ export async function GET(req: Request) {
   const plantId = searchParams.get('plantId')
   const type = searchParams.get('type')
   const userName = searchParams.get('user')
-  const where: any = { plant: { userId: user.id } }
+  const where: any = { userId: user.id }
   if (plantId) where.plantId = plantId
   if (type) where.type = type as any
   if (userName) where.userName = userName

--- a/src/app/api/photos/[id]/route.ts
+++ b/src/app/api/photos/[id]/route.ts
@@ -26,14 +26,14 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
     }
 
     // remove db record
-    await prisma.photo.delete({ where: { id: params.id, userId: user.id } as any });
+    await prisma.photo.delete({ where: { id: params.id, userId: user.id } });
 
     // if it was cover, pick another photo (if any) as cover
     const plant = await prisma.plant.findFirst({ where: { id: photo.plantId, userId: user.id }, select: { coverPhotoId: true } });
     if (plant?.coverPhotoId === photo.id) {
       const fallback = await prisma.photo.findFirst({ where: { plantId: photo.plantId, userId: user.id } });
       await prisma.plant.update({
-        where: { id: photo.plantId },
+        where: { id: photo.plantId, userId: user.id },
         data: { coverPhotoId: fallback?.id ?? null },
       });
     }
@@ -58,7 +58,7 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     const photo = await prisma.photo.findFirst({ where: { id: params.id, userId: user.id } });
     if (!photo) return NextResponse.json({ error: 'not found' }, { status: 404 });
 
-    await prisma.plant.update({ where: { id: photo.plantId }, data: { coverPhotoId: photo.id, userId: user.id } as any });
+    await prisma.plant.update({ where: { id: photo.plantId, userId: user.id }, data: { coverPhotoId: photo.id } });
 
     return NextResponse.json({ ok: true });
   } catch (e: any) {

--- a/src/app/api/plants/[id]/events.csv/route.ts
+++ b/src/app/api/plants/[id]/events.csv/route.ts
@@ -21,7 +21,7 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
   const plant = await prisma.plant.findFirst({ where: { id: params.id, userId: user.id } })
   if (!plant) return NextResponse.json({ error: 'not found' }, { status: 404 })
   const events = await prisma.careEvent.findMany({
-    where: { plantId: params.id, plant: { userId: user.id } },
+    where: { plantId: params.id, userId: user.id },
     orderBy: { createdAt: 'desc' },
   })
 
@@ -67,7 +67,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
   const rows = parseCsv(csv)
 
   const events = rows.map((row) => {
-    const ev: any = { plantId: params.id }
+    const ev: any = { plantId: params.id, userId: user.id }
     for (const [col, value] of Object.entries(row)) {
       const field = (mapping as Record<string, string>)[col] ?? col
       if (!value) continue

--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -44,7 +44,7 @@ export async function DELETE(_: Request, { params }: { params: { id: string } })
   const plant = await prisma.plant.findFirst({ where: { id: params.id, userId: user.id } })
   if (!plant) return NextResponse.json({ error: 'not found' }, { status: 404 })
   await prisma.photo.deleteMany({ where: { plantId: params.id, userId: user.id } })
-  await prisma.careEvent.deleteMany({ where: { plantId: params.id, plant: { userId: user.id } } })
+  await prisma.careEvent.deleteMany({ where: { plantId: params.id, userId: user.id } })
   await prisma.plant.delete({ where: { id: params.id } })
   return NextResponse.json({ ok: true })
 }

--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -7,7 +7,7 @@ export async function GET() {
   const user = await getSessionUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const rooms = await prisma.room.findMany({
-    where: { userId: user.id } as any,
+    where: { userId: user.id },
     orderBy: { sortOrder: 'asc' },
   })
   return NextResponse.json(rooms)
@@ -19,8 +19,8 @@ export async function POST(req: Request) {
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const json = await req.json(); const parsed = schema.safeParse(json)
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
-  const count = await prisma.room.count({ where: { userId: user.id } as any })
-  const room = await prisma.room.create({ data: { name: parsed.data.name, sortOrder: count, userId: user.id } as any })
+  const count = await prisma.room.count({ where: { userId: user.id } })
+  const room = await prisma.room.create({ data: { name: parsed.data.name, sortOrder: count, userId: user.id } })
   return NextResponse.json(room, { status: 201 })
 }
 
@@ -32,7 +32,7 @@ export async function PUT(req: Request) {
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
   await prisma.$transaction(
     parsed.data.order.map((r) =>
-      prisma.room.update({ where: { id: r.id, userId: user.id } as any, data: { sortOrder: r.sortOrder, userId: user.id } as any })
+      prisma.room.update({ where: { id: r.id, userId: user.id }, data: { sortOrder: r.sortOrder, userId: user.id } })
     )
   )
   return NextResponse.json({ status: 'ok' })

--- a/src/app/api/share/[id]/route.ts
+++ b/src/app/api/share/[id]/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: Request, { params }: Params) {
   const password = new URL(req.url).searchParams.get('password') ?? undefined;
 
   const link = await prisma.shareLink.findFirst({
-    where: { id, userId: user.id } as any,
+    where: { id, userId: user.id },
     include: {
       plant: { include: { photos: true, events: true } },
       room: { include: { plants: { include: { photos: true, events: true } } } },

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: Request) {
     if (!plant) return NextResponse.json({ error: 'not found' }, { status: 404 });
   }
   if (type === 'room') {
-    const room = await prisma.room.findFirst({ where: { id, userId: user.id } as any });
+    const room = await prisma.room.findFirst({ where: { id, userId: user.id } });
     if (!room) return NextResponse.json({ error: 'not found' }, { status: 404 });
   }
 

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -43,7 +43,7 @@ export default async function PlantsPage({ searchParams }: { searchParams: { q?:
 
   const [plantsRaw, rooms] = await Promise.all([
     prisma.plant.findMany({ include: { photos: true, room: true }, where, orderBy: { createdAt: 'desc' } }),
-    prisma.room.findMany({ where: { plants: { some: { userId } } }, orderBy: { name: 'asc' } }),
+    prisma.room.findMany({ where: { userId }, orderBy: { name: 'asc' } }),
   ])
 
   let plants = plantsRaw

--- a/src/app/rooms/page.tsx
+++ b/src/app/rooms/page.tsx
@@ -23,7 +23,7 @@ export default async function RoomsPage() {
   const userId = session.user.id
 
   const rooms = await prisma.room.findMany({
-    where: { plants: { some: { userId } } },
+    where: { userId },
     include: { plants: { where: { userId } } },
     orderBy: { sortOrder: 'asc' },
   })


### PR DESCRIPTION
## Summary
- add userId fields and indexes to Room, Plant, Photo, and CareEvent Prisma models
- seed test data with userId values
- update API routes and pages to query by userId

## Testing
- `npx prisma generate`
- `DIRECT_URL="postgresql://user:pass@localhost:5432/db" DATABASE_URL="postgresql://user:pass@localhost:5432/db" npx prisma migrate dev --name add-user-id-fields` *(fails: Can't reach database server)*
- `DIRECT_URL="postgresql://user:pass@localhost:5432/db" DATABASE_URL="postgresql://user:pass@localhost:5432/db" npx prisma db push` *(fails: Can't reach database server)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895fa31ce888324b285fea69857c74f