### PR TITLE
feat: add PWA offline support

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "Plant Care",
+  "short_name": "PlantCare",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#16a34a",
+  "icons": [
+    { "src": "/icon-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icon-512x512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,70 @@
+const CACHE_NAME = 'plant-care-cache-v1';
+const STATIC_ASSETS = [
+  '/',
+  '/icon-192x192.png',
+  '/icon-512x512.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+
+  // Handle navigation requests
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then(response => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
+          return response;
+        })
+        .catch(() => caches.match(request))
+    );
+    return;
+  }
+
+  // Cache images and uploaded photos with a cache-first strategy
+  if (request.destination === 'image' || request.url.includes('/uploads/')) {
+    event.respondWith(
+      caches.match(request).then(cached => {
+        return (
+          cached ||
+          fetch(request)
+            .then(response => {
+              const copy = response.clone();
+              caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
+              return response;
+            })
+            .catch(() => cached)
+        );
+      })
+    );
+    return;
+  }
+
+  // Cache API responses to allow offline access to recent data
+  if (request.url.includes('/api/')) {
+    event.respondWith(
+      fetch(request)
+        .then(response => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
+          return response;
+        })
+        .catch(() => caches.match(request))
+    );
+  }
+});

--- a/src/app/api/uploads/route.ts
+++ b/src/app/api/uploads/route.ts
@@ -53,6 +53,8 @@ export async function POST(req: NextRequest) {
         plantId,
         objectKey: key,
         url,
+        // TODO: generate a separate thumbnail URL; use main URL for now
+        thumbUrl: url,
         contentType: file.type || undefined,
       },
     });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,17 @@
 import './globals.css'
 import type { Metadata } from 'next'
+import ServiceWorkerRegistration from '../components/ServiceWorkerRegistration'
 
-export const metadata: Metadata = { title: 'Plant Care (Local Dev)', description: 'No-cloud local dev build' }
+export const metadata: Metadata = {
+  title: 'Plant Care (Local Dev)',
+  description: 'No-cloud local dev build',
+  manifest: '/manifest.json',
+  themeColor: '#16a34a',
+  icons: {
+    icon: '/icon-192x192.png',
+    apple: '/icon-192x192.png'
+  }
+}
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -18,6 +28,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           </div>
         </header>
         <main className="container py-6">{children}</main>
+        <ServiceWorkerRegistration />
       </body>
     </html>
   )

--- a/src/components/ServiceWorkerRegistration.tsx
+++ b/src/components/ServiceWorkerRegistration.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function ServiceWorkerRegistration() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/service-worker.js');
+      });
+    }
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add web app manifest and service worker registration
- precache UI assets and cache API/image responses for offline use
- reuse existing app icons and include thumbUrl in upload metadata to satisfy build

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6895ee5a50fc8324862877cd83255bb8