### PR TITLE
Scope share link lookup to current user

### DIFF
--- a/src/app/api/share/[id]/route.ts
+++ b/src/app/api/share/[id]/route.ts
@@ -14,7 +14,13 @@ export async function GET(req: Request, { params }: Params) {
   const password = new URL(req.url).searchParams.get('password') ?? undefined;
 
   const link = await prisma.shareLink.findFirst({
-    where: { id, userId: user.id },
+    where: {
+      id,
+      OR: [
+        { plant: { userId: user.id } },
+        { room: { userId: user.id } },
+      ],
+    },
     include: {
       plant: { include: { photos: true, events: true } },
       room: { include: { plants: { include: { photos: true, events: true } } } },


### PR DESCRIPTION
## Summary
- Ensure share link API only returns links for plants or rooms owned by the session user

## Testing
- `npm test`
- `npx tsc --noEmit`
- `npm run build` *(fails: SyntaxError: Expected ',' or '}' after property value in JSON at position 94128)*

------
https://chatgpt.com/codex/tasks/task_e_6895fce55f348324b8c214e279608ead