### PR TITLE
Enforce user-scoped API access

### DIFF
--- a/src/app/api/backup/route.ts
+++ b/src/app/api/backup/route.ts
@@ -1,15 +1,29 @@
 import { prisma } from '@/lib/db'
 import { NextResponse } from 'next/server'
-import { getSessionUser } from '@/lib/auth'
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+async function getUserId() {
+  const cookieStore = cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { getAll: () => cookieStore.getAll() } }
+  )
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  return session?.user.id ?? null
+}
 
 export async function GET() {
-  const user = await getSessionUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const userId = await getUserId()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const [rooms, plants, photos, careEvents, species] = await Promise.all([
-    prisma.room.findMany({ where: { userId: user.id } }),
-    prisma.plant.findMany({ where: { userId: user.id } }),
-    prisma.photo.findMany({ where: { userId: user.id } }),
-    prisma.careEvent.findMany({ where: { userId: user.id } }),
+    prisma.room.findMany({ where: { userId } }),
+    prisma.plant.findMany({ where: { userId } }),
+    prisma.photo.findMany({ where: { userId } }),
+    prisma.careEvent.findMany({ where: { userId } }),
     prisma.species.findMany(),
   ])
 
@@ -24,22 +38,22 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
-  const user = await getSessionUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const userId = await getUserId()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const data = await req.json()
 
   await prisma.$transaction([
-    prisma.careEvent.deleteMany({ where: { userId: user.id } }),
-    prisma.photo.deleteMany({ where: { userId: user.id } }),
-    prisma.plant.deleteMany({ where: { userId: user.id } }),
-    prisma.room.deleteMany({ where: { userId: user.id } }),
+    prisma.careEvent.deleteMany({ where: { userId } }),
+    prisma.photo.deleteMany({ where: { userId } }),
+    prisma.plant.deleteMany({ where: { userId } }),
+    prisma.room.deleteMany({ where: { userId } }),
   ])
 
-  if (data.rooms?.length) await prisma.room.createMany({ data: data.rooms.map((r: any) => ({ ...r, userId: user.id })) })
-  if (data.plants?.length) await prisma.plant.createMany({ data: data.plants.map((p: any) => ({ ...p, userId: user.id })) })
-  if (data.photos?.length) await prisma.photo.createMany({ data: data.photos.map((p: any) => ({ ...p, userId: user.id })) })
+  if (data.rooms?.length) await prisma.room.createMany({ data: data.rooms.map((r: any) => ({ ...r, userId })) })
+  if (data.plants?.length) await prisma.plant.createMany({ data: data.plants.map((p: any) => ({ ...p, userId })) })
+  if (data.photos?.length) await prisma.photo.createMany({ data: data.photos.map((p: any) => ({ ...p, userId })) })
   if (data.careEvents?.length)
-    await prisma.careEvent.createMany({ data: data.careEvents.map((e: any) => ({ ...e, userId: user.id })) })
+    await prisma.careEvent.createMany({ data: data.careEvents.map((e: any) => ({ ...e, userId })) })
 
   return NextResponse.json({ ok: true })
 }

--- a/src/app/api/photos/[id]/route.ts
+++ b/src/app/api/photos/[id]/route.ts
@@ -2,18 +2,34 @@ import { NextResponse } from 'next/server';
 import { DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { prisma } from '@/lib/db';
 import { r2, R2_BUCKET } from '@/lib/r2';
-import { getSessionUser } from '@/lib/auth';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+async function getUserId() {
+  const cookieStore = cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: { getAll: () => cookieStore.getAll() },
+    }
+  );
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  return session?.user.id ?? null;
+}
 
 export const runtime = 'nodejs';
 
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
   try {
-    const user = await getSessionUser();
-    if (!user) {
+    const userId = await getUserId();
+    if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const photo = await prisma.photo.findFirst({ where: { id: params.id, userId: user.id } });
+    const photo = await prisma.photo.findFirst({ where: { id: params.id, userId } });
     if (!photo) return NextResponse.json({ error: 'not found' }, { status: 404 });
 
     // delete blobs in R2 (full + thumb)
@@ -26,15 +42,15 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
     }
 
     // remove db record
-    await prisma.photo.delete({ where: { id: params.id, userId: user.id } });
+    await prisma.photo.deleteMany({ where: { id: params.id, userId } });
 
     // if it was cover, pick another photo (if any) as cover
-    const plant = await prisma.plant.findFirst({ where: { id: photo.plantId, userId: user.id }, select: { coverPhotoId: true } });
+    const plant = await prisma.plant.findFirst({ where: { id: photo.plantId, userId }, select: { coverPhotoId: true } });
     if (plant?.coverPhotoId === photo.id) {
-      const fallback = await prisma.photo.findFirst({ where: { plantId: photo.plantId, userId: user.id } });
+      const fallback = await prisma.photo.findFirst({ where: { plantId: photo.plantId, userId } });
       await prisma.plant.update({
-        where: { id: photo.plantId, userId: user.id },
-        data: { coverPhotoId: fallback?.id ?? null },
+        where: { id: photo.plantId, userId },
+        data: { coverPhotoId: fallback?.id ?? null, userId },
       });
     }
 
@@ -47,18 +63,18 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
   try {
-    const user = await getSessionUser();
-    if (!user) {
+    const userId = await getUserId();
+    if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const { action } = await req.json();
     if (action !== 'cover') return NextResponse.json({ error: 'unsupported action' }, { status: 400 });
 
-    const photo = await prisma.photo.findFirst({ where: { id: params.id, userId: user.id } });
+    const photo = await prisma.photo.findFirst({ where: { id: params.id, userId } });
     if (!photo) return NextResponse.json({ error: 'not found' }, { status: 404 });
 
-    await prisma.plant.update({ where: { id: photo.plantId, userId: user.id }, data: { coverPhotoId: photo.id } });
+    await prisma.plant.update({ where: { id: photo.plantId, userId }, data: { coverPhotoId: photo.id, userId } });
 
     return NextResponse.json({ ok: true });
   } catch (e: any) {

--- a/src/app/api/plants/[id]/events.csv/route.ts
+++ b/src/app/api/plants/[id]/events.csv/route.ts
@@ -1,6 +1,20 @@
 import { prisma } from '@/lib/db'
 import { NextResponse } from 'next/server'
-import { getSessionUser } from '@/lib/auth'
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+async function getUserId() {
+  const cookieStore = cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { getAll: () => cookieStore.getAll() } }
+  )
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  return session?.user.id ?? null
+}
 
 function parseCsv(text: string) {
   const lines = text.trim().split(/\r?\n/)
@@ -16,12 +30,12 @@ function parseCsv(text: string) {
 }
 
 export async function GET(_: Request, { params }: { params: { id: string } }) {
-  const user = await getSessionUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const plant = await prisma.plant.findFirst({ where: { id: params.id, userId: user.id } })
+  const userId = await getUserId()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const plant = await prisma.plant.findFirst({ where: { id: params.id, userId } })
   if (!plant) return NextResponse.json({ error: 'not found' }, { status: 404 })
   const events = await prisma.careEvent.findMany({
-    where: { plantId: params.id, userId: user.id },
+    where: { plantId: params.id, userId },
     orderBy: { createdAt: 'desc' },
   })
 
@@ -59,15 +73,15 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
 }
 
 export async function POST(req: Request, { params }: { params: { id: string } }) {
-  const user = await getSessionUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const plant = await prisma.plant.findFirst({ where: { id: params.id, userId: user.id } })
+  const userId = await getUserId()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const plant = await prisma.plant.findFirst({ where: { id: params.id, userId } })
   if (!plant) return NextResponse.json({ error: 'not found' }, { status: 404 })
   const { csv, mapping = {} } = await req.json()
   const rows = parseCsv(csv)
 
   const events = rows.map((row) => {
-    const ev: any = { plantId: params.id, userId: user.id }
+    const ev: any = { plantId: params.id, userId }
     for (const [col, value] of Object.entries(row)) {
       const field = (mapping as Record<string, string>)[col] ?? col
       if (!value) continue

--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -1,13 +1,27 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { z } from 'zod'
-import { getSessionUser } from '@/lib/auth'
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+async function getUserId() {
+  const cookieStore = cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { getAll: () => cookieStore.getAll() } }
+  )
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  return session?.user.id ?? null
+}
 
 export async function GET() {
-  const user = await getSessionUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const userId = await getUserId()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const rooms = await prisma.room.findMany({
-    where: { userId: user.id },
+    where: { userId },
     orderBy: { sortOrder: 'asc' },
   })
   return NextResponse.json(rooms)
@@ -15,24 +29,24 @@ export async function GET() {
 
 const schema = z.object({ name: z.string().min(1) })
 export async function POST(req: Request) {
-  const user = await getSessionUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const userId = await getUserId()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const json = await req.json(); const parsed = schema.safeParse(json)
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
-  const count = await prisma.room.count({ where: { userId: user.id } })
-  const room = await prisma.room.create({ data: { name: parsed.data.name, sortOrder: count, userId: user.id } })
+  const count = await prisma.room.count({ where: { userId } })
+  const room = await prisma.room.create({ data: { name: parsed.data.name, sortOrder: count, userId } })
   return NextResponse.json(room, { status: 201 })
 }
 
 const orderSchema = z.object({ order: z.array(z.object({ id: z.string(), sortOrder: z.number() })) })
 export async function PUT(req: Request) {
-  const user = await getSessionUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const userId = await getUserId()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const json = await req.json(); const parsed = orderSchema.safeParse(json)
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
   await prisma.$transaction(
     parsed.data.order.map((r) =>
-      prisma.room.update({ where: { id: r.id, userId: user.id }, data: { sortOrder: r.sortOrder, userId: user.id } })
+      prisma.room.update({ where: { id: r.id, userId }, data: { sortOrder: r.sortOrder, userId } })
     )
   )
   return NextResponse.json({ status: 'ok' })

--- a/src/app/api/species/hints/route.ts
+++ b/src/app/api/species/hints/route.ts
@@ -1,11 +1,27 @@
 import { NextResponse } from 'next/server'
 import { suggestWaterMl, baselineIntervalDays, adjustIntervalDays, fertilizerIntervalDays } from '@/lib/estimation'
 import { LightLevel, PotMaterial } from '@prisma/client'
-import { getSessionUser } from '@/lib/auth'
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+async function getUserId() {
+  const cookieStore = cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: { getAll: () => cookieStore.getAll() },
+    }
+  )
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  return session?.user.id ?? null
+}
 
 export async function POST(req: Request) {
-  const user = await getSessionUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const userId = await getUserId()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const body = await req.json().catch(() => ({}))
   const {
     scientificName,

--- a/src/app/api/tasks/daily/route.ts
+++ b/src/app/api/tasks/daily/route.ts
@@ -1,16 +1,30 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { computeTaskLists } from '@/lib/tasks'
-import { getSessionUser } from '@/lib/auth'
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+async function getUserId() {
+  const cookieStore = cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { getAll: () => cookieStore.getAll() } }
+  )
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  return session?.user.id ?? null
+}
 
 export const dynamic = 'force-dynamic'
 
 // Endpoint for Vercel Cron (~7 AM) to compute daily task lists
 export async function GET() {
-  const user = await getSessionUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const userId = await getUserId()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const plants = await prisma.plant.findMany({
-    where: { userId: user.id },
+    where: { userId },
     orderBy: { createdAt: 'desc' },
   })
   const lists = computeTaskLists(plants)

--- a/src/app/api/tasks/reminder/route.ts
+++ b/src/app/api/tasks/reminder/route.ts
@@ -2,16 +2,30 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { computeTaskLists } from '@/lib/tasks'
 import { sendTaskDigest } from '@/lib/email'
-import { getSessionUser } from '@/lib/auth'
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+async function getUserId() {
+  const cookieStore = cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { getAll: () => cookieStore.getAll() } }
+  )
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  return session?.user.id ?? null
+}
 
 export const dynamic = 'force-dynamic'
 
 // Vercel Cron to email daily task digest
 export async function GET() {
-  const user = await getSessionUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const userId = await getUserId()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const plants = await prisma.plant.findMany({
-    where: { userId: user.id },
+    where: { userId },
     orderBy: { createdAt: 'desc' },
   })
   const { today } = computeTaskLists(plants)

--- a/src/app/api/uploads/local/route.ts
+++ b/src/app/api/uploads/local/route.ts
@@ -3,15 +3,31 @@ import { R2_BUCKET, s3, PUBLIC_HOSTNAME } from '@/lib/s3'
 import { PutObjectCommand } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { randomUUID } from 'crypto'
-import { getSessionUser } from '@/lib/auth'
 import { prisma } from '@/lib/db'
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+async function getUserId() {
+  const cookieStore = cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: { getAll: () => cookieStore.getAll() },
+    }
+  )
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  return session?.user.id ?? null
+}
 
 export async function POST(req: Request) {
-  const user = await getSessionUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const userId = await getUserId()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { plantId, contentType, ext } = await req.json()
   if (!plantId) return NextResponse.json({ error: 'plantId required' }, { status: 400 })
-  const plant = await prisma.plant.findFirst({ where: { id: plantId, userId: user.id } })
+  const plant = await prisma.plant.findFirst({ where: { id: plantId, userId } })
   if (!plant) return NextResponse.json({ error: 'not found' }, { status: 404 })
   const key = `${plantId}/${randomUUID()}.${(ext || 'jpg').replace(/[^a-zA-Z0-9]/g, '')}`
 

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -14,3 +14,11 @@ test('plants route uses userId scoping', () => {
 test('photo delete route checks userId', () => {
   assert.ok(hasUserScope('src/app/api/photos/[id]/route.ts'));
 });
+
+test('plant detail route checks userId', () => {
+  assert.ok(hasUserScope('src/app/api/plants/[id]/route.ts'));
+});
+
+test('uploads route checks userId', () => {
+  assert.ok(hasUserScope('src/app/api/uploads/route.ts'));
+});


### PR DESCRIPTION
## Summary
- require a valid Supabase session for all API routes
- scope database queries and mutations by userId
- add tests ensuring critical endpoints enforce ownership

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895ff44acfc8324b4ee4c3b4a521b45