### PR TITLE
Check plant ownership and photo user scopes

### DIFF
--- a/src/app/api/uploads/local/route.ts
+++ b/src/app/api/uploads/local/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: Request) {
   if (!plantId) return NextResponse.json({ error: 'plantId required' }, { status: 400 })
   const plant = await prisma.plant.findFirst({ where: { id: plantId, userId } })
   if (!plant) return NextResponse.json({ error: 'not found' }, { status: 404 })
-  const key = `${plantId}/${randomUUID()}.${(ext || 'jpg').replace(/[^a-zA-Z0-9]/g, '')}`
+  const key = `users/${userId}/plants/${plantId}/${randomUUID()}.${(ext || 'jpg').replace(/[^a-zA-Z0-9]/g, '')}`
 
   const command = new PutObjectCommand({
     Bucket: R2_BUCKET,


### PR DESCRIPTION
## Summary
- scope uploads to authenticated user's plants and object paths when presigning
- include user-owned paths for local upload keys
- ensure photo delete and cover update verify ownership

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896020946648324ab09948c7eab4382