### PR TITLE
Secure daily tasks endpoint with auth and service key

### DIFF
--- a/src/app/api/tasks/daily/route.ts
+++ b/src/app/api/tasks/daily/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { computeTaskLists } from '@/lib/tasks'
 import { createServerClient } from '@supabase/ssr'
@@ -20,9 +20,22 @@ async function getUserId() {
 export const dynamic = 'force-dynamic'
 
 // Endpoint for Vercel Cron (~7 AM) to compute daily task lists
-export async function GET() {
-  const userId = await getUserId()
-  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+export async function GET(request: NextRequest) {
+  let userId = await getUserId()
+
+  if (!userId) {
+    const serviceKey = request.headers.get('x-service-key')
+    if (serviceKey !== process.env.SUPABASE_SERVICE_ROLE_KEY) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const userParam = request.nextUrl.searchParams.get('userId')
+    if (!userParam) {
+      return NextResponse.json({ error: 'Missing userId' }, { status: 400 })
+    }
+    userId = userParam
+  }
+
   const plants = await prisma.plant.findMany({
     where: { userId },
     orderBy: { createdAt: 'desc' },


### PR DESCRIPTION
## Summary
- Require authentication or service key to access daily tasks
- Support cron usage with service key and explicit userId
- Ensure Prisma queries are scoped by user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68960494b5e08324a97597f5e7a0e1f6