### PR TITLE
Add plant care reporting and export utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,9 @@
         "date-fns": "^3.6.0",
         "ioredis": "^5.4.1",
         "next": "^14.2.5",
+        "node-cron": "^4.2.1",
         "nodemailer": "^7.0.5",
+        "pdfkit": "^0.17.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "sharp": "^0.33.2",
@@ -3202,6 +3204,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3241,6 +3263,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -3410,6 +3441,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -3506,6 +3546,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3570,6 +3616,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -3668,6 +3720,12 @@
         "node": ">=14.16.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -3737,6 +3795,32 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fontkit/node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/foreground-child": {
@@ -4028,6 +4112,12 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4045,6 +4135,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lines-and-columns": {
@@ -4301,6 +4410,15 @@
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "license": "MIT"
     },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-gyp-build-optional-packages": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
@@ -4388,6 +4506,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -4420,6 +4544,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pdfkit": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.1.tgz",
+      "integrity": "sha512-Kkf1I9no14O/uo593DYph5u3QwiMfby7JsBSErN1WqeyTgCBNJE3K4pXBn3TgkdKUIVu+buSl4bYUNC+8Up4xg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.4",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
       }
     },
     "node_modules/picocolors": {
@@ -4460,6 +4597,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -4715,6 +4857,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -5157,6 +5305,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5228,6 +5382,26 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "seed": "tsx prisma/seed.ts",
     "postinstall": "prisma generate",
     "test": "node --import tsx --test tests/access.test.ts",
-    "worker": "node --import tsx src/worker/imageProcessor.ts"
+    "worker": "node --import tsx src/worker/imageProcessor.ts",
+    "report:monthly": "node --import tsx scripts/exportMonthlyReport.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.863.0",
@@ -21,14 +22,16 @@
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.54.0",
     "@vercel/analytics": "^1.5.0",
-    "date-fns": "^3.6.0",
-    "next": "^14.2.5",
-    "nodemailer": "^7.0.5",
     "bullmq": "^4.12.0",
+    "date-fns": "^3.6.0",
     "ioredis": "^5.4.1",
-    "sharp": "^0.33.2",
+    "next": "^14.2.5",
+    "node-cron": "^4.2.1",
+    "nodemailer": "^7.0.5",
+    "pdfkit": "^0.17.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "sharp": "^0.33.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/scripts/exportMonthlyReport.ts
+++ b/scripts/exportMonthlyReport.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+import fs from 'node:fs'
+import cron from 'node-cron'
+import PDFDocument from 'pdfkit'
+import { format, startOfMonth, endOfMonth, subMonths } from 'date-fns'
+import { prisma } from '../src/lib/db'
+import { getUsageTimeline, getOverdueStats } from '../src/lib/stats'
+
+async function generate(userId: string) {
+  const start = startOfMonth(subMonths(new Date(), 1))
+  const end = endOfMonth(subMonths(new Date(), 1))
+  const usage = await getUsageTimeline(userId, start, end)
+  const overdue = await getOverdueStats(userId)
+  const month = format(start, 'yyyy-MM')
+
+  const csvLines = ['date,waterMl,fertilizerMl']
+  const days = Array.from(new Set([...Object.keys(usage.water), ...Object.keys(usage.fertilizer)])).sort()
+  for (const d of days) {
+    csvLines.push(`${d},${usage.water[d] || 0},${usage.fertilizer[d] || 0}`)
+  }
+  fs.writeFileSync(`monthly-report-${month}.csv`, csvLines.join('\n'))
+
+  const doc = new PDFDocument()
+  doc.pipe(fs.createWriteStream(`monthly-report-${month}.pdf`))
+  doc.fontSize(18).text('Monthly Plant Care Summary', { align: 'center' })
+  doc.moveDown()
+  doc.fontSize(12).text(`Period: ${format(start, 'yyyy-MM-dd')} - ${format(end, 'yyyy-MM-dd')}`)
+  const totalWater = Object.values(usage.water).reduce((a, b) => a + b, 0)
+  const totalFert = Object.values(usage.fertilizer).reduce((a, b) => a + b, 0)
+  doc.text(`Total water used: ${totalWater} mL`)
+  doc.text(`Total fertilizer used: ${totalFert} mL`)
+  doc.text(`Overdue watering rate: ${(overdue.overdueWaterRate * 100).toFixed(1)}%`)
+  doc.text(`Overdue fertilizing rate: ${(overdue.overdueFertilizerRate * 100).toFixed(1)}%`)
+  doc.text(`Plants at risk: ${overdue.plantsAtRisk.length}`)
+  doc.end()
+}
+
+const userId = process.argv[2]
+if (!userId) {
+  console.error('Usage: npm run report:monthly -- <userId> [--schedule]')
+  process.exit(1)
+}
+
+if (process.argv.includes('--schedule')) {
+  cron.schedule('0 0 1 * *', () => {
+    generate(userId).catch((e) => console.error(e))
+  })
+} else {
+  generate(userId)
+    .catch((e) => console.error(e))
+    .finally(() => prisma.$disconnect())
+}

--- a/src/app/api/reports/stats/route.ts
+++ b/src/app/api/reports/stats/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import { subDays } from 'date-fns'
+import { getUsageTimeline, getOverdueStats } from '@/lib/stats'
+
+async function getUserId() {
+  const cookieStore = cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { getAll: () => cookieStore.getAll() } }
+  )
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  return session?.user.id ?? null
+}
+
+export async function GET(req: Request) {
+  const userId = await getUserId()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const { searchParams } = new URL(req.url)
+  const days = Number(searchParams.get('days')) || 30
+  const from = subDays(new Date(), days)
+  const usage = await getUsageTimeline(userId, from)
+  const overdue = await getOverdueStats(userId)
+  return NextResponse.json({ usage, overdue })
+}

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,0 +1,56 @@
+import { format, subDays, differenceInDays } from 'date-fns'
+import { prisma } from './db'
+import { nextWaterDate, nextFertilizeDate } from './schedule'
+
+export async function getUsageTimeline(
+  userId: string,
+  from: Date,
+  to: Date = new Date()
+) {
+  const events = await prisma.careEvent.findMany({
+    where: {
+      userId,
+      type: { in: ['WATER', 'FERTILIZE'] },
+      createdAt: { gte: from, lte: to },
+    },
+    select: { type: true, amountMl: true, createdAt: true },
+  })
+  const water: Record<string, number> = {}
+  const fertilizer: Record<string, number> = {}
+  for (const e of events) {
+    const day = format(e.createdAt, 'yyyy-MM-dd')
+    const amt = e.amountMl ?? 0
+    if (e.type === 'WATER') water[day] = (water[day] ?? 0) + amt
+    else if (e.type === 'FERTILIZE')
+      fertilizer[day] = (fertilizer[day] ?? 0) + amt
+  }
+  return { water, fertilizer }
+}
+
+export async function getOverdueStats(userId: string) {
+  const plants = await prisma.plant.findMany({ where: { userId } })
+  const total = plants.length
+  let overdueWater = 0
+  let overdueFertilizer = 0
+  const atRisk = new Set<string>()
+  const now = new Date()
+  for (const p of plants) {
+    const nextW = nextWaterDate(p)
+    if (nextW < now) {
+      overdueWater++
+      if (differenceInDays(now, nextW) > p.wateringIntervalDays)
+        atRisk.add(p.id)
+    }
+    const nextF = nextFertilizeDate(p)
+    if (nextF < now) {
+      overdueFertilizer++
+      if (differenceInDays(now, nextF) > p.fertilizingIntervalDays)
+        atRisk.add(p.id)
+    }
+  }
+  return {
+    overdueWaterRate: total ? overdueWater / total : 0,
+    overdueFertilizerRate: total ? overdueFertilizer / total : 0,
+    plantsAtRisk: Array.from(atRisk),
+  }
+}


### PR DESCRIPTION
## Summary
- add utilities to compute usage timelines, overdue rates, and at-risk plants
- expose `/api/reports/stats` endpoint with optional time range
- create monthly report script generating CSV/PDF with optional scheduling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68960c1bb7e48324a2261c0a3382c985