### PR TITLE
Remove duplicate main layout to fix double login

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,22 +34,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang="en">
       <body>
-
-        <header className="border-b border-slate-200 dark:border-slate-800">
-          <div className="container py-4 flex items-center justify-between">
-            <h1 className="text-xl font-semibold">🌿 Plant Care (Local)</h1>
-            <nav className="flex items-center gap-4 text-sm">
-              <a className="hover:underline" href="/">Today</a>
-              <a className="hover:underline" href="/plants">My Plants</a>
-              <a className="hover:underline" href="/rooms">Rooms</a>
-            </nav>
-          </div>
-        </header>
-        <main className="container py-6">{children}</main>
-        <ServiceWorkerRegistration />
-        <InstallPrompt />
-        <CareEventQueueProvider />
-
         <SupabaseProvider initialSession={session}>
           <header className="border-b border-slate-200 dark:border-slate-800">
             <div className="container py-4 flex items-center justify-between">
@@ -66,8 +50,11 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           <main className="container py-6">{children}</main>
         </SupabaseProvider>
 
-        {process.env.NODE_ENV === 'production' && <Analytics />}
+        <ServiceWorkerRegistration />
+        <InstallPrompt />
+        <CareEventQueueProvider />
 
+        {process.env.NODE_ENV === 'production' && <Analytics />}
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- render children once by wrapping layout in a single SupabaseProvider
- keep service worker, install prompt and queue providers outside Supabase provider

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896168ac1a08324bdc573fcee2423d6