### PR TITLE
Relax CSP for development in Next.js

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,13 @@
 /** @type {import('next').NextConfig} */
+const scriptSrc =
+  process.env.NODE_ENV === 'development'
+    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+    : "script-src 'self'"
+
 const securityHeaders = [
   {
     key: 'Content-Security-Policy',
-    value: "default-src 'self'; img-src 'self' data: https:; script-src 'self'; style-src 'self' 'unsafe-inline';",
+    value: `default-src 'self'; img-src 'self' data: https:; ${scriptSrc}; style-src 'self' 'unsafe-inline';`,
   },
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'X-Frame-Options', value: 'DENY' },


### PR DESCRIPTION
## Summary
- loosen `script-src` policy during development by permitting inline and eval scripts

## Testing
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68961eeddaec832498e1fcca0723b9a4